### PR TITLE
Add install and release rake tasks from Bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@
 #
 # Copyright (c) 2011, Sebastian Staudt
 
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubygems/package_task'
 


### PR DESCRIPTION
You can take or leave this change, but it makes installing and releasing gems more convenient. `rake install` and `rake release` respectively.