### PR TITLE
Add ‘libbz2.so.1’ alternate library name for FFI

### DIFF
--- a/lib/rbzip2/ffi.rb
+++ b/lib/rbzip2/ffi.rb
@@ -13,7 +13,7 @@ module RBzip2::FFI
   def self.init
     begin
       extend ::FFI::Library
-      ffi_lib 'bz2'
+      ffi_lib ['bz2', 'libbz2.so.1']
     rescue NameError, LoadError
       @@available = false
     end


### PR DESCRIPTION
I was investigating why FFI version was not activating in spite of having libbz2 (1.0.6-8) installed on Ubuntu.  I found that only "libbz2.so.1" symlink is created, and not "libbz2.so" when this package is installed.  The latter is only created by the "libbz2-dev" package.

Without "libbz2.so", calling `ffi_lib 'bz2'` fails.   

This PR is to alternatively try to load "libbz2.so.1" to handle this case.

This technique is described here:
https://github.com/ffi/ffi/wiki/Loading-Libraries#linux-packages