### PR TITLE
Fixes to ‘libbz2.so.1’ alternate name for FFI

### DIFF
--- a/lib/rbzip2/ffi.rb
+++ b/lib/rbzip2/ffi.rb
@@ -9,11 +9,12 @@ rescue LoadError
 end
 
 module RBzip2::FFI
+  LIBBZ2 = ['bz2', 'libbz2.so.1']
 
   def self.init
     begin
       extend ::FFI::Library
-      ffi_lib ['bz2', 'libbz2.so.1']
+      ffi_lib LIBBZ2
     rescue NameError, LoadError
       @@available = false
     end

--- a/lib/rbzip2/ffi/compressor.rb
+++ b/lib/rbzip2/ffi/compressor.rb
@@ -8,7 +8,7 @@ class RBzip2::FFI::Compressor
 
   extend ::FFI::Library
 
-  ffi_lib 'bz2'
+  ffi_lib ::RBzip2::FFI::LIBBZ2
   attach_function :BZ2_bzBuffToBuffCompress,
                   [:pointer, :buffer_inout, :pointer, :uint32, :int, :int, :int],
                   :int

--- a/lib/rbzip2/ffi/decompressor.rb
+++ b/lib/rbzip2/ffi/decompressor.rb
@@ -16,7 +16,7 @@ class RBzip2::FFI::Decompressor
                   [:pointer],
                   :int
 
-  ffi_lib 'bz2'
+  ffi_lib ::RBzip2::FFI::LIBBZ2
   attach_function :BZ2_bzRead,
                   [:pointer, :pointer, :pointer, :int],
                   :int


### PR DESCRIPTION
Looks like I didn't fully understand things before the prior PR.  My prior change only fixed the FFI availability check, but not the compressor/decompressor classes.

This PR completes my fix.

I used LIBBZ2 constant to match LIBC convention seen in Decompressor class.